### PR TITLE
fixed uncorrect offset during daylight saving time

### DIFF
--- a/lib/time_zone_ext.rb
+++ b/lib/time_zone_ext.rb
@@ -7,7 +7,7 @@ module TimeZoneExt
     if format =~ /%z/i
       DateTime.strptime(date, format).in_time_zone
     else
-      DateTime.strptime("#{date} zone#{formatted_offset}", "#{format} zone%z").in_time_zone
+      DateTime.strptime("#{date} zone#{now.formatted_offset}", "#{format} zone%z").in_time_zone
     end
   end
 end


### PR DESCRIPTION
formatted_offset is not returning correct offset during daylight saving time. Calling now.formatted_offset corrects this behavior.
